### PR TITLE
This is an update to make the source property bindable, and keep it update via Javascript as the user browses within an iframe.

### DIFF
--- a/library/src/com/google/code/flexiframe/IFrame.as
+++ b/library/src/com/google/code/flexiframe/IFrame.as
@@ -28,7 +28,7 @@ package com.google.code.flexiframe
     import flash.geom.Point;
     import flash.utils.Dictionary;
     import flash.utils.getQualifiedClassName;
-
+    
     import mx.controls.ToolTip;
     import mx.core.Application;
     import mx.core.Container;
@@ -519,7 +519,14 @@ package com.google.code.flexiframe
                 logger.debug("frame id {0} calling queued function {1}", _frameId, queuedCall.functionName);
                 this.callIFrameFunction(queuedCall.functionName, queuedCall.args, queuedCall.callback);
             }
-            dispatchEvent(new Event("frameLoad"));
+			
+			var newSource:String = getBrowserSource();
+			if (newSource && newSource != "" && newSource != source) {
+				_source = newSource;
+				dispatchEvent(new Event("browserSourceChanged"));
+			}
+
+			dispatchEvent(new Event("frameLoad"));
 
             invalidateDisplayList();
         }
@@ -597,6 +604,7 @@ package com.google.code.flexiframe
             if (source)
             {
                 _source=source;
+				dispatchEvent(new Event("browserSourceChanged"));
 
                 // mark unloaded now so calls in this frame will be queued
                 _frameLoaded=false;
@@ -610,6 +618,7 @@ package com.google.code.flexiframe
         /**
          * Return url of frame contents
          */
+		[Bindable (event="browserSourceChanged")]
         public function get source():String
         {
             return _source;
@@ -1217,6 +1226,7 @@ package com.google.code.flexiframe
             ExternalInterface.call(IFrameExternalCalls.INSERT_FUNCTION_PRINT_IFRAME);
             ExternalInterface.call(IFrameExternalCalls.INSERT_FUNCTION_HISTORY_BACK);
             ExternalInterface.call(IFrameExternalCalls.INSERT_FUNCTION_HISTORY_FORWARD);
+			ExternalInterface.call(IFrameExternalCalls.INSERT_FUNCTION_GET_SOURCE);
 
             // Resolve the SWF embed object id in the DOM.
             ExternalInterface.call(IFrameExternalCalls.INSERT_FUNCTION_ASK_FOR_EMBED_OBJECT_ID);
@@ -1341,6 +1351,20 @@ package com.google.code.flexiframe
             }
             return new Number(0);
         }
+		
+		/**
+		 * Get the browser source.
+		 */
+		protected function getBrowserSource():String 
+		{
+			logger.info("Get browser source.");
+			var result:Object = ExternalInterface.call(IFrameExternalCalls.FUNCTION_GET_SOURCE, _iframeId);
+			if (result != null)
+			{
+				return result as String;
+			}
+			return "";
+		}
 
         /**
          * Setup the Browser resize event listener.

--- a/library/src/com/google/code/flexiframe/IFrameExternalCalls.as
+++ b/library/src/com/google/code/flexiframe/IFrameExternalCalls.as
@@ -528,6 +528,29 @@ package com.google.code.flexiframe
                    "}" +
                 "}" +
             "}";
+		
+		
+		
+		/**
+		 * The name of the JavaScript function that hides a Div.
+		 */
+		public static var FUNCTION_GET_SOURCE:String = "getSource";
+
+		
+		/**
+		 * The Javascript code to call to insert the function that returns the IFrame's source.
+		 */
+		public static var INSERT_FUNCTION_GET_SOURCE:String =
+			"document.insertScript = function () " +
+			"{ " +
+				"if (document." + FUNCTION_GET_SOURCE + "==null) " +
+				"{ " +
+					FUNCTION_GET_SOURCE + " = function(iframeID) " + 
+					"{ " + 
+						"return document.getElementById(iframeID).contentDocument.URL; " +
+					"} " +
+				"} " + 
+			"}";
 
     }
 }


### PR DESCRIPTION
Tested in several browsers (Chrome, Firefox, Safari) and works.  The feature cannot update the source if the location is cross-domain, due to a browser's cross-domain security restrictions.  However, within the same domain, the source will update and databinding will kick in.  

This can be used to show the current URL in a UI with data binding {myIFrame.source} or update a URL input field.  My test UI listens for "frameLoad" event and updates an input URL field from myIFrame.source at that time.
